### PR TITLE
Removes break-word formatting & fixes salary input width for mobile.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -82,7 +82,11 @@ sup {
   margin-left: 0.5rem; }
 
 input {
-  text-align: center; }
+  text-align: center;
+  width: 100%; }
+  @media only screen and (min-width: 480px) {
+    input {
+      width: auto; } }
 
 .headline {
   line-height: 1.2;
@@ -120,24 +124,6 @@ input {
 
 #random-spend {
   padding: 1rem 0rem; }
-
-.break-words {
-  /* These are technically the same, but use both */
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-  -ms-word-break: break-all;
-  /* This is the dangerous one in WebKit, as it breaks things wherever */
-  word-break: break-all;
-  /* Instead use this non-standard one: */
-  word-break: break-word;
-  /* Adds a hyphen where the word breaks, if supported (No Blink) */
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto; }
-
-.dont-break-words {
-  word-break: normal; }
 
 .button {
   cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
     <section id="salary" class="flex-item flex-full blue-block">
       <hr>
 
-      <div id="random-spend" class="hidden break-words">
-        <p>Rauner's campaign spends <span id="random-phrase"></span> ($<span id="random-amount"></span>) in <span id="random-time" class="break-words"></span>. <sup><a href="#2">2</a></sup></p>
+      <div id="random-spend" class="hidden">
+        <p>Rauner's campaign spends <span id="random-phrase"></span> ($<span id="random-amount"></span>) in <span id="random-time"></span>. <sup><a href="#2">2</a></sup></p>
       </div>
 
       <button type="button" id="random-fact" class="button">show another fact</button>

--- a/sass/index.scss
+++ b/sass/index.scss
@@ -125,6 +125,11 @@ sup {
 
 input {
   text-align: center;
+  width: 100%;
+
+  @media only screen and (min-width:480px) {
+    width: auto;
+  }
 }
 
 
@@ -176,29 +181,6 @@ input {
 
 #random-spend {
   padding: 1rem 0rem;
-}
-
-// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
-.break-words {
-  /* These are technically the same, but use both */
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-
-  -ms-word-break: break-all;
-  /* This is the dangerous one in WebKit, as it breaks things wherever */
-  word-break: break-all;
-  /* Instead use this non-standard one: */
-  word-break: break-word;
-
-  /* Adds a hyphen where the word breaks, if supported (No Blink) */
-  -ms-hyphens: auto;
-  -moz-hyphens: auto;
-  -webkit-hyphens: auto;
-  hyphens: auto;
-}
-
-.dont-break-words {
-  word-break: normal;
 }
 
 .button {


### PR DESCRIPTION
The `break-word` formatting results in awkward word breaks. Unless I'm missing something, it doesn't appear to be necessary.

Also fixes salary input width for small mobile screens (currently causes horizontal scrolling at ~320px).